### PR TITLE
fix stack full behavior

### DIFF
--- a/jobstack.go
+++ b/jobstack.go
@@ -97,10 +97,9 @@ func (s *Stack) run() {
 				j.notify <- nil
 			} else {
 				if s.stack.full() {
-					oldest := s.stack.shift()
-					oldest.notify <- ErrStackFull
+					j.notify <- ErrStackFull
+					continue
 				}
-
 				s.stack.push(j)
 			}
 		case <-s.done:


### PR DESCRIPTION
If the stack is full we want to wait to process at least some of the jobs.
Before we cleaned up the bottom, such that no job could be processed at all.

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>