### PR TITLE
add possibility to reconfigure the queue

### DIFF
--- a/jobqueue.go
+++ b/jobqueue.go
@@ -58,15 +58,16 @@ type Status struct {
 // Using a stack for job processing can be a good way to protect an application from
 // bursts of chatty clients or temporarily slow job execution.
 type Stack struct {
-	options Options
-	stack   *stack
-	req     chan *job
-	done    chan struct{}
-	quit    chan bool
-	closing bool
-	status  chan chan Status
-	hasQuit chan struct{}
-	busy    int
+	options   Options
+	stack     *stack
+	req       chan *job
+	done      chan struct{}
+	quit      chan bool
+	closing   bool
+	status    chan chan Status
+	configure chan Options
+	hasQuit   chan struct{}
+	busy      int
 }
 
 var token struct{}
@@ -98,13 +99,14 @@ func With(o Options) *Stack {
 	}
 
 	s := &Stack{
-		options: o,
-		stack:   newStack(o.MaxStackSize),
-		req:     make(chan *job),
-		done:    make(chan struct{}),
-		quit:    make(chan bool),
-		hasQuit: make(chan struct{}),
-		status:  make(chan chan Status),
+		options:   o,
+		stack:     newStack(o.MaxStackSize),
+		req:       make(chan *job),
+		done:      make(chan struct{}),
+		quit:      make(chan bool),
+		hasQuit:   make(chan struct{}),
+		status:    make(chan chan Status),
+		configure: make(chan Options),
 	}
 
 	go s.run()
@@ -129,6 +131,10 @@ func (s *Stack) run() {
 
 		select {
 		case j := <-s.req:
+			if s.options.Timeout > 0 {
+				j.timeout = time.After(s.options.Timeout)
+			}
+
 			if s.closing {
 				j.notify <- ErrClosed
 			} else if s.busy < s.options.MaxConcurrency {
@@ -159,6 +165,24 @@ func (s *Stack) run() {
 			s.stack.shift()
 		case status := <-s.status:
 			status <- Status{ActiveJobs: s.busy, QueuedJobs: s.stack.list.Len(), Closing: s.closing}
+		case o := <-s.configure:
+			if o.MaxConcurrency <= 0 {
+				o.MaxConcurrency = 1
+			}
+
+			s.options = o
+			s.stack.cap = o.MaxStackSize
+
+			for s.busy < s.options.MaxConcurrency && !s.stack.empty() {
+				s.busy++
+				j := s.stack.pop()
+				j.notify <- nil
+			}
+
+			for s.stack.list.Len() > s.stack.cap {
+				j := s.stack.shift()
+				j.notify <- ErrStackFull
+			}
 		case forced := <-s.quit:
 			if forced {
 				s.rejectQueued()
@@ -184,12 +208,7 @@ func (s *Stack) run() {
 }
 
 func (s *Stack) newJob() *job {
-	j := &job{notify: make(chan error)}
-	if s.options.Timeout > 0 {
-		j.timeout = time.After(s.options.Timeout)
-	}
-
-	return j
+	return &job{notify: make(chan error)}
 }
 
 // Wait returns when a job can be processed, or it should be cancelled. The notion of
@@ -253,6 +272,15 @@ func (s *Stack) Status() Status {
 		return <-req
 	}
 
+}
+
+func (s *Stack) Reconfigure(o Options) error {
+	select {
+	case <-s.hasQuit:
+		return ErrClosed
+	case s.configure <- o:
+		return nil
+	}
 }
 
 // Close frees up the resources used by a Stack instance.

--- a/jobqueue.go
+++ b/jobqueue.go
@@ -150,7 +150,7 @@ func (s *Stack) run() {
 			}
 		case <-s.done:
 			s.busy--
-			if !s.stack.empty() {
+			if !s.stack.empty() && s.busy < s.options.MaxConcurrency {
 				s.busy++
 				j := s.stack.pop()
 				j.notify <- nil


### PR DESCRIPTION
allows applying new settings to the queue. If there are more items being processed than what the new configuration allows, they will still be allowed to finish. If there are more items on the stack than the new configuration allows, the stack will reject enough old items.